### PR TITLE
GitHub Linguist support for adblock filters

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.txt linguist-detectable

--- a/Personal/Personal_BLF.txt
+++ b/Personal/Personal_BLF.txt
@@ -1,3 +1,4 @@
+[uBlock Origin]
 ! Title: Nimasa personal adblock filter list
 ! Expires: 2 days (update frequency)
 ! Version: 0.1

--- a/archive/BLF.txt
+++ b/archive/BLF.txt
@@ -1,3 +1,4 @@
+[uBlock Origin]
 ! Title: MyNext uBlock filter list
 ! Expires: 2 days (update frequency)
 ! Version: 2.0

--- a/uBOPa-light.txt
+++ b/uBOPa-light.txt
@@ -1,3 +1,4 @@
+[uBlock Origin]
 ! Title: uBOPa-light filter list
 ! Expires: 2 days (update frequency)
 ! Version: 3.0

--- a/uBOPa.txt
+++ b/uBOPa.txt
@@ -1,3 +1,4 @@
+[uBlock Origin]
 ! Title: uBOPa filter list
 ! Expires: 2 days (update frequency)
 ! Version: 2206


### PR DESCRIPTION
GitHub has been supporting adblock syntax highlighting since September 5th. This PR will help you turn it on.

Further informations:
- Syntax highlighter repository: https://github.com/ameshkov/VscodeAdblockSyntax
- How Linguist works: https://github.com/github/linguist/blob/master/docs/how-linguist-works.md
- Linguist overrides: https://github.com/github/linguist/blob/master/docs/overrides.md
- Linguist commit: https://github.com/github/linguist/commit/e78ef71af3600f96b9a40a06511ebbe3797e7401